### PR TITLE
Support non-Spotify (Soundtrack) tracks in queue and now playing

### DIFF
--- a/renderer/components/Queue/nowPlayingCard.tsx
+++ b/renderer/components/Queue/nowPlayingCard.tsx
@@ -8,6 +8,7 @@ import truenorth_logo from "@public/images/truenorth_logo.png";
 import { useAsideBreakpoint } from "@providers/AsideBreakpointContext";
 import { useSonosActions, useSonosState } from "@providers/SonosContext";
 import type { Track } from "@svrooij/sonos/lib/models";
+import { extractTrackReference } from "../../utils/sonosUri";
 
 export default function NowPlayingCard() {
   const [albumArtUri, setAlbumArtUri] = useState<string | StaticImageData>(
@@ -21,17 +22,13 @@ export default function NowPlayingCard() {
 
   const actions = useSonosActions();
   const state = useSonosState();
-  const extractSpotifyTrackUri = (sonosUri: string): string | null => {
-    if (!sonosUri) return null;
-    const match = sonosUri.match(/(spotify:track:[^?]+)/);
-    return match ? match[1] : null;
-  };
-
   useEffect(() => {
     const nowPlaying = state?.playbackState?.positionInfo
       ?.TrackMetaData as Track;
+    const trackReference = extractTrackReference(nowPlaying?.TrackUri);
+    if (!trackReference) return;
     actions
-      .getTrack(extractSpotifyTrackUri(nowPlaying?.TrackUri))
+      .getTrack(trackReference.ref, trackReference.serviceId)
       .then((track) => {
         console.log("Now Playing Track:", track);
         setAlbumName(track.album.name);

--- a/renderer/components/providers/QueueProvider.tsx
+++ b/renderer/components/providers/QueueProvider.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as SonosContext from "./SonosContext";
 import type { TN_Track } from "../../models/Track";
 import type { TN_Album } from "@models/Album";
+import { extractTrackReference } from "../../utils/sonosUri";
 
 interface QueueContextType {
   currentTrackIndex: number;
@@ -34,13 +35,6 @@ export const QueueProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   const [followingQueue, setFollowingQueue] = useState<boolean>(true);
 
-  const extractSpotifyTrackUri = (sonosUri: string): string | null => {
-    if (!sonosUri) return null;
-    const match = sonosUri.match(/(spotify:track:[^?]+)/);
-    console.log("Extracted Spotify URI:", match ? match[1] : null);
-    return match ? match[1] : null;
-  };
-
   // Fetch Sonos queue and map URIs to full track objects
   const queueQuery = useQuery<TN_Track[], unknown, TN_Track[]>({
     queryKey: ["queue"],
@@ -50,9 +44,13 @@ export const QueueProvider: FC<{ children: ReactNode }> = ({ children }) => {
         raw.map((item) => {
           if (item.TrackUri === undefined)
             console.log("Undefined TrackUri for item:", item);
-          const uri = extractSpotifyTrackUri(item.TrackUri);
-          if (!uri) return Promise.resolve(null as unknown as TN_Track);
-          return sonosActions.getTrack(uri);
+          const trackReference = extractTrackReference(item.TrackUri);
+          if (!trackReference)
+            return Promise.resolve(null as unknown as TN_Track);
+          return sonosActions.getTrack(
+            trackReference.ref,
+            trackReference.serviceId
+          );
         })
       );
       console.log("Fetched queue:", tracks);

--- a/renderer/components/providers/SonosContext.tsx
+++ b/renderer/components/providers/SonosContext.tsx
@@ -88,7 +88,7 @@ interface SonosActions {
     skip?: number,
     count?: number
   ) => Promise<MediaList>;
-  getTrack: (ref: string) => Promise<TN_Track>;
+  getTrack: (ref: string, serviceId?: Services | number) => Promise<TN_Track>;
   getAlbum: (ref: string) => Promise<TN_Album>;
   getArtist: (ref: string) => Promise<TN_Artist>;
   getItemMetadata: (itemId: string) => Promise<MediaList>;
@@ -638,13 +638,14 @@ function createActions(
     removeRangeFromQueue: (index, count) => {
       sonos.RemoveTrackRangeFromQueue(index, count);
     },
-    getTrack: async (ref) => {
+    getTrack: async (ref, serviceId = Services.Spotify) => {
       if (!ref) return undefined;
-      if (trackCache.has(ref)) {
-        return trackCache.get(ref)!;
+      const cacheKey = `${serviceId}:${ref}`;
+      if (trackCache.has(cacheKey)) {
+        return trackCache.get(cacheKey)!;
       }
 
-      const metatadata = (await sonos.GetItemMetadata(Services.Spotify, ref))
+      const metatadata = (await sonos.GetItemMetadata(serviceId, ref))
         .mediaMetadata[0] as ITrackEntity;
       const md = metatadata.trackMetadata;
       if (!md) console.log("No trackMetadata for ref:", ref);
@@ -660,7 +661,7 @@ function createActions(
         explicit: (metatadata.tags?.explicit ?? 0) === 1,
       };
 
-      trackCache.set(ref, track);
+      trackCache.set(cacheKey, track);
       return track;
     },
     getAlbum: async (ref) => {

--- a/renderer/utils/sonosUri.ts
+++ b/renderer/utils/sonosUri.ts
@@ -1,0 +1,14 @@
+export const extractTrackReference = (
+  sonosUri?: string | null
+): { ref: string; serviceId?: number } | null => {
+  if (!sonosUri) return null;
+  const decodedUri = decodeURIComponent(sonosUri);
+  const trackMatch = decodedUri.match(/([a-z0-9-]+:track:[^?]+)/i);
+  if (!trackMatch) return null;
+
+  const sidMatch =
+    decodedUri.match(/[?&]sid=(\d+)/i) ?? sonosUri.match(/[?&]sid=(\d+)/i);
+  const serviceId = sidMatch ? Number(sidMatch[1]) : undefined;
+
+  return { ref: trackMatch[1], serviceId };
+};


### PR DESCRIPTION
### Motivation
- Sonos queue and now-playing screens currently only resolve Spotify URIs, so tracks from other services (e.g. Soundtrack) do not show full metadata.
- Sonos track URIs can include an embedded service id (`sid`) and URL-encoded data which must be decoded and handled per-service.
- The change aims to correctly extract service-aware track references and fetch metadata from the appropriate music service.

### Description
- Added a shared helper `extractTrackReference` in `renderer/utils/sonosUri.ts` that decodes Sonos URIs and returns the track `ref` plus optional `serviceId` parsed from `sid` query params.
- Updated `QueueProvider` to use `extractTrackReference` when mapping `TrackUri` values and to call `getTrack(ref, serviceId)` so queue entries from non-Spotify services are resolved.
- Updated `nowPlayingCard` to use `extractTrackReference` for the current `TrackUri` and call `getTrack(ref, serviceId)` for now-playing metadata.
- Extended `getTrack` in `SonosContext` to accept an optional `serviceId`, to call `sonos.GetItemMetadata(serviceId, ref)`, and to cache tracks per-service using a `serviceId:ref` cache key.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967b1fe6eac832c8de48f15e915afa8)