### PR TITLE
Handle music service auth and service-aware track lookup (Soundtrack support)

### DIFF
--- a/main/SonosGroupManager.ts
+++ b/main/SonosGroupManager.ts
@@ -1,5 +1,6 @@
 import type { SonosDevice } from '@svrooij/sonos';
 import { SonosEvents, SonosManager } from '@svrooij/sonos'
+import type { SmapiClient } from '@svrooij/sonos/lib/musicservices/smapi-client';
 import { mainWindow } from './background';
 import type { Track } from '@svrooij/sonos/lib/models';
 import type { Services } from '../renderer/enums/Services';
@@ -12,6 +13,8 @@ class SonosGroupManager {
 
     private manager: SonosManager;
     private coordinator: SonosDevice | undefined;
+    private serviceClients = new Map<number, SmapiClient>();
+    private serviceAuth = new Map<number, { authToken: string; key: string }>();
 
     constructor() {
         this.manager = new SonosManager();
@@ -42,14 +45,49 @@ class SonosGroupManager {
     }
 
 
+    private async getMusicServiceClient(serviceId: number) {
+        if (!this.coordinator) return undefined;
+        if (this.serviceClients.has(serviceId)) {
+            return this.serviceClients.get(serviceId);
+        }
+        const auth = this.serviceAuth.get(serviceId);
+        const musicService = await this.coordinator.MusicServicesClient(serviceId, auth);
+        this.serviceClients.set(serviceId, musicService);
+        return musicService;
+    }
+
+    private async authenticateService(serviceId: number) {
+        if (!this.coordinator) return undefined;
+        const musicService = await this.coordinator.MusicServicesClient(serviceId);
+        const link = await musicService.GetLoginLink();
+        console.log('Link URL: ', link.regUrl, ' Enter code: ', link.linkCode);
+        const credentials = await musicService.GetDeviceAuthToken(link.linkCode);
+        this.serviceAuth.set(serviceId, {
+            authToken: credentials.authToken,
+            key: credentials.privateKey
+        });
+        const authenticatedService = await this.coordinator.MusicServicesClient(serviceId, {
+            authToken: credentials.authToken,
+            key: credentials.privateKey
+        });
+        this.serviceClients.set(serviceId, authenticatedService);
+        return authenticatedService;
+    }
+
+    private isNoAuthTokenError(error: unknown): boolean {
+        if (!error) return false;
+        if (error instanceof Error && error.message.toLowerCase().includes('no auth token')) {
+            return true;
+        }
+        if (typeof error !== 'object') return false;
+        const fault = (error as { Fault?: { detail?: { ExceptionInfo?: string } } }).Fault;
+        const exceptionInfo = fault?.detail?.ExceptionInfo;
+        return typeof exceptionInfo === 'string' && exceptionInfo.toLowerCase().includes('no auth token');
+    }
+
     public async ConnectToServices() {
         try {
-            let spotify = await this.coordinator?.MusicServicesClient(SonosService.Spotify);
-            const link = await spotify.GetLoginLink();
-            console.log('Link URL: ', link.regUrl, ' Enter code: ', link.linkCode);
-            const credentials = await spotify.GetDeviceAuthToken(link.linkCode);
-            spotify = await this.coordinator?.MusicServicesClient(SonosService.Spotify, credentials);
-
+            const spotify = await this.authenticateService(SonosService.Spotify);
             console.log(spotify);
         } catch (e) {
             console.log(e);
@@ -86,7 +124,7 @@ class SonosGroupManager {
 
     public async Search(term: string, searchType: string, service: Services, resultCount: number, skip: number = 0) {
         if (this.coordinator) {
-            const musicService = await this.coordinator.MusicServicesClient(service);
+            const musicService = await this.getMusicServiceClient(service);
             try {
                 const result = await musicService.Search({ id: searchType, term, index: skip, count: resultCount });
                 return result;
@@ -112,7 +150,7 @@ class SonosGroupManager {
 
     public async GetRootPage(service: Services) {
         if (this.coordinator) {
-            const musicService = await this.coordinator.MusicServicesClient(service);
+            const musicService = await this.getMusicServiceClient(service);
             const result = await musicService.GetMetadata({ id: 'root', index: 0, count: 15, recursive: true });
             return result;
         }
@@ -120,15 +158,25 @@ class SonosGroupManager {
 
     public async GetItemMetadata(service: Services, id: string) {
         if (this.coordinator) {
-            const musicService = await this.coordinator.MusicServicesClient(service);
-            const result = await musicService.GetExtendedMetadata({ id });
-            return result;
+            const musicService = await this.getMusicServiceClient(service);
+            try {
+                const result = await musicService.GetExtendedMetadata({ id });
+                return result;
+            } catch (e) {
+                if (this.isNoAuthTokenError(e)) {
+                    const authenticatedService = await this.authenticateService(service);
+                    if (authenticatedService) {
+                        return authenticatedService.GetExtendedMetadata({ id });
+                    }
+                }
+                console.log(e);
+            }
         }
     }
 
     public async GetMetadata(service: Services, id: string, skip: number = 0, count: number = 15) {
         if (this.coordinator) {
-            const musicService = await this.coordinator.MusicServicesClient(service);
+            const musicService = await this.getMusicServiceClient(service);
             const result = await musicService.GetMetadata({ id, index: skip, count, recursive: true });
             return result;
         }

--- a/renderer/components/Queue/nowPlayingCard.tsx
+++ b/renderer/components/Queue/nowPlayingCard.tsx
@@ -8,6 +8,7 @@ import truenorth_logo from "@public/images/truenorth_logo.png";
 import { useAsideBreakpoint } from "@providers/AsideBreakpointContext";
 import { useSonosActions, useSonosState } from "@providers/SonosContext";
 import type { Track } from "@svrooij/sonos/lib/models";
+import { extractTrackReference } from "../../utils/sonosUri";
 
 export default function NowPlayingCard() {
   const [albumArtUri, setAlbumArtUri] = useState<string | StaticImageData>(
@@ -21,17 +22,13 @@ export default function NowPlayingCard() {
 
   const actions = useSonosActions();
   const state = useSonosState();
-  const extractSpotifyTrackUri = (sonosUri: string): string | null => {
-    if (!sonosUri) return null;
-    const match = sonosUri.match(/(spotify:track:[^?]+)/);
-    return match ? match[1] : null;
-  };
-
   useEffect(() => {
     const nowPlaying = state?.playbackState?.positionInfo
       ?.TrackMetaData as Track;
+    const trackReference = extractTrackReference(nowPlaying?.TrackUri);
+    if (!trackReference) return;
     actions
-      .getTrack(extractSpotifyTrackUri(nowPlaying?.TrackUri))
+      .getTrack(trackReference.ref, trackReference.serviceId)
       .then((track) => {
         console.log("Now Playing Track:", track);
         setAlbumName(track.album.name);

--- a/renderer/components/providers/QueueProvider.tsx
+++ b/renderer/components/providers/QueueProvider.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import * as SonosContext from "./SonosContext";
 import type { TN_Track } from "../../models/Track";
 import type { TN_Album } from "@models/Album";
+import { extractTrackReference } from "../../utils/sonosUri";
 
 interface QueueContextType {
   currentTrackIndex: number;
@@ -34,13 +35,6 @@ export const QueueProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   const [followingQueue, setFollowingQueue] = useState<boolean>(true);
 
-  const extractSpotifyTrackUri = (sonosUri: string): string | null => {
-    if (!sonosUri) return null;
-    const match = sonosUri.match(/(spotify:track:[^?]+)/);
-    console.log("Extracted Spotify URI:", match ? match[1] : null);
-    return match ? match[1] : null;
-  };
-
   // Fetch Sonos queue and map URIs to full track objects
   const queueQuery = useQuery<TN_Track[], unknown, TN_Track[]>({
     queryKey: ["queue"],
@@ -50,9 +44,13 @@ export const QueueProvider: FC<{ children: ReactNode }> = ({ children }) => {
         raw.map((item) => {
           if (item.TrackUri === undefined)
             console.log("Undefined TrackUri for item:", item);
-          const uri = extractSpotifyTrackUri(item.TrackUri);
-          if (!uri) return Promise.resolve(null as unknown as TN_Track);
-          return sonosActions.getTrack(uri);
+          const trackReference = extractTrackReference(item.TrackUri);
+          if (!trackReference)
+            return Promise.resolve(null as unknown as TN_Track);
+          return sonosActions.getTrack(
+            trackReference.ref,
+            trackReference.serviceId
+          );
         })
       );
       console.log("Fetched queue:", tracks);

--- a/renderer/components/providers/SonosContext.tsx
+++ b/renderer/components/providers/SonosContext.tsx
@@ -88,7 +88,7 @@ interface SonosActions {
     skip?: number,
     count?: number
   ) => Promise<MediaList>;
-  getTrack: (ref: string) => Promise<TN_Track>;
+  getTrack: (ref: string, serviceId?: Services | number) => Promise<TN_Track>;
   getAlbum: (ref: string) => Promise<TN_Album>;
   getArtist: (ref: string) => Promise<TN_Artist>;
   getItemMetadata: (itemId: string) => Promise<MediaList>;
@@ -638,13 +638,14 @@ function createActions(
     removeRangeFromQueue: (index, count) => {
       sonos.RemoveTrackRangeFromQueue(index, count);
     },
-    getTrack: async (ref) => {
+    getTrack: async (ref, serviceId = Services.Spotify) => {
       if (!ref) return undefined;
-      if (trackCache.has(ref)) {
-        return trackCache.get(ref)!;
+      const cacheKey = `${serviceId}:${ref}`;
+      if (trackCache.has(cacheKey)) {
+        return trackCache.get(cacheKey)!;
       }
 
-      const metatadata = (await sonos.GetItemMetadata(Services.Spotify, ref))
+      const metatadata = (await sonos.GetItemMetadata(serviceId, ref))
         .mediaMetadata[0] as ITrackEntity;
       const md = metatadata.trackMetadata;
       if (!md) console.log("No trackMetadata for ref:", ref);
@@ -660,7 +661,7 @@ function createActions(
         explicit: (metatadata.tags?.explicit ?? 0) === 1,
       };
 
-      trackCache.set(ref, track);
+      trackCache.set(cacheKey, track);
       return track;
     },
     getAlbum: async (ref) => {

--- a/renderer/utils/sonosUri.ts
+++ b/renderer/utils/sonosUri.ts
@@ -1,0 +1,14 @@
+export const extractTrackReference = (
+  sonosUri?: string | null
+): { ref: string; serviceId?: number } | null => {
+  if (!sonosUri) return null;
+  const decodedUri = decodeURIComponent(sonosUri);
+  const trackMatch = decodedUri.match(/([a-z0-9-]+:track:[^?]+)/i);
+  if (!trackMatch) return null;
+
+  const sidMatch =
+    decodedUri.match(/[?&]sid=(\d+)/i) ?? sonosUri.match(/[?&]sid=(\d+)/i);
+  const serviceId = sidMatch ? Number(sidMatch[1]) : undefined;
+
+  return { ref: trackMatch[1], serviceId };
+};


### PR DESCRIPTION
### Motivation
- Calls to `GetItemMetadata` for non-Spotify services (e.g. Soundtrack) can fail with "No auth token", causing track metadata to be missing for queue / now-playing screens.
- The app needs to reuse Sonos SMAPI clients and stored credentials so metadata calls can be authenticated and retried when required.
- Track lookups must be service-aware so non-Spotify URIs are resolved against the correct music service.

### Description
- Add cached service clients and credential storage in `main/SonosGroupManager.ts` with `serviceClients` and `serviceAuth` maps and a `getMusicServiceClient` helper to reuse clients.
- Implement `authenticateService` and `isNoAuthTokenError` in `SonosGroupManager` and add retry-on-auth logic in `GetItemMetadata` to re-authenticate and replay metadata calls when a "No auth token" error is detected.
- Route `Search`, `GetRootPage`, and `GetMetadata` through the cached client via `getMusicServiceClient` so service access is consistent and re-usable.
- Add `extractTrackReference` helper in `renderer/utils/sonosUri.ts` and update `QueueProvider` and `nowPlayingCard` to use it, and update `SonosContext` `getTrack` to accept an optional `serviceId` and cache tracks with a `serviceId:ref` key so non-Spotify tracks are fetched from the correct service.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6967b1fe6eac832c8de48f15e915afa8)